### PR TITLE
specified empty_class_id

### DIFF
--- a/scripts/execute_experiments.py
+++ b/scripts/execute_experiments.py
@@ -109,7 +109,7 @@ def main(repo_dir: str, experiment: str):
     }
     empty_class_id = load_json(
         os.path.join(cfg['data_dir'], 'label_map.json')
-        ).get('empty')
+    ).get('empty')
 
     evaluator_is = Evaluator(
         label_file_path=os.path.join(cfg['data_dir'], cfg['label_file']),


### PR DESCRIPTION
The class id of the empty label must be correctly specified for Evaluator.